### PR TITLE
Silencing the 'update' method

### DIFF
--- a/gp/recipe/node/__init__.py
+++ b/gp/recipe/node/__init__.py
@@ -92,4 +92,5 @@ class Recipe(object):
         rscripts = Scripts(self.buildout, self.name, options)
         return rscripts.install()
 
-    update = install
+    def update(self):
+        pass


### PR DESCRIPTION
I believe the 'install' method is supposed to kick in whenever the part config changes so the 'update' method here appears to be working too hard and just makes subsequent buildout runs unnecessarily verbose.
