### PR TITLE
Fixing inverted condition which causes a failure when no download cache is configured

### DIFF
--- a/gp/recipe/node/__init__.py
+++ b/gp/recipe/node/__init__.py
@@ -74,7 +74,7 @@ class Recipe(object):
                 # The buildout download utility expects us to know whether or
                 # not we have a download cache, which causes fun errors.  This
                 # is probably a bug, but this test should be safe regardless.
-                if not manager.download_cache:
+                if manager.download_cache:
                     filename = manager.download_cached(url)[0]
                 else:
                     filename = manager.download(url)[0]


### PR DESCRIPTION
Apologies for this, didn't notice it when I created the original pull request.
