### PR TITLE
Fixes a failure installing npms when the buildout path contains spaces

### DIFF
--- a/gp/recipe/node/__init__.py
+++ b/gp/recipe/node/__init__.py
@@ -128,8 +128,6 @@ class Recipe(object):
             npms = ' '.join([npm.strip() for npm in npms.split()
                              if npm.strip()])
             
-            escaped_dir = shell_quote(node_dir)
-            
             p = subprocess.Popen((
                 'export HOME=%(node_dir)s;'
                 'export PATH=%(node_bin)s:$PATH;'


### PR DESCRIPTION
Fixed by quoting the paths before interpolating them into the commands.
