### PR TITLE
Add support for Buildout offline mode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 0.12.7.2 (unreleased)
 =====================
 
-- Nothing changed yet.
+- Add support for offline mode in Buildout (`-o`)
 
 
 0.12.7.1 (2015-09-01)


### PR DESCRIPTION
See #29.  This adds support for offline mode, essentially following what zc.recipe.egg does.

When offline mode is in place, the Node download only proceeds from cache (passes option through) and in terms of package installs, checks npm install status if offline.  If not yet installed or packages not installed, raises an error.  If these conditions succeed, then `npm install` is bypassed.